### PR TITLE
Empty or wrong input allowed

### DIFF
--- a/app/assets/javascripts/edit.js.coffee
+++ b/app/assets/javascripts/edit.js.coffee
@@ -7,16 +7,20 @@
 window.G or= {}
 
 window.G.begin_editing = (editor_selector, autosave_selector) ->
-  console.groupCollapsed("Preparing to edit a file")
+  $(autosave_selector).hide()
   setup_features()
+  if not doc? or doc == ""
+    notify "Unable to load file", "error"
+
+  console.groupCollapsed("Preparing to edit a file")
 
   if window.isRestore
     console.groupCollapsed("An autosaved version exists")
+    $(autosave_selector).show()
     G.Autosave.handle(editor_selector, autosave_selector, ->
       G.begin_editing(editor_selector, autosave_selector))
     console.groupEnd()
   else
-    $(autosave_selector).hide()
 
     # G.debug_editor = new G.GorillaEditor(autosave_selector)
     G.main_editor = new G.GorillaEditor(editor_selector, doc, G.debug_editor)

--- a/app/assets/javascripts/edit.js.coffee
+++ b/app/assets/javascripts/edit.js.coffee
@@ -11,6 +11,7 @@ window.G.begin_editing = (editor_selector, autosave_selector) ->
   setup_features()
   if not doc? or doc == ""
     notify "Unable to load file", "error"
+    return
 
   console.groupCollapsed("Preparing to edit a file")
 


### PR DESCRIPTION
Currently, if all the fields are left empty, or just type random strings into the first input box, clicking "Open file" will lead to an empty page.

Ideally, an error page or pop up should appear to alert the user for empty or invalid inputs. Opening a file that does not exist seems to be fine.
# cs169test
