### PR TITLE
Multiple pop up boxes

### DIFF
--- a/app/assets/javascripts/features.js.coffee
+++ b/app/assets/javascripts/features.js.coffee
@@ -47,10 +47,13 @@ populateTable = (features) ->
            id: id,
            ->
              notify("Successfully deleted feature", "success")
-             $.get "/feature/getAll", {user_id: user}, (data) ->
-               window.allFeatures = data.features
-               populateTable(window.allFeatures)
-               $('#allfeaturesdialog').dialog("open")
+             update_all_features_dialog()
+
+update_all_features_dialog = ->
+  $.get "/feature/getAll", {user_id: user}, (data) ->
+    window.allFeatures = data.features
+    populateTable(window.allFeatures)
+    $('#allfeaturesdialog').dialog("open")
 
 reset_features_form = ->
   $('feature-form').each -> $(this).reset()
@@ -120,6 +123,7 @@ window.bind_features = ->
                notify("Successfully saved feature", "success")
                $("#featuredialog").dialog("close")
                reset_features_form()
+               update_all_features_dialog()
 
   $('#addFeature').unbind('click').click ->
     $('#featuredialog').dialog("open")
@@ -128,11 +132,7 @@ window.bind_features = ->
     if window.allFeatures != null
       populateTable(window.allFeatures)
       $('#allfeaturesdialog').dialog("open")
-
-    $.get "/feature/getAll", {user_id: user}, (data) ->
-      window.allFeatures = data.features
-      populateTable(window.allFeatures)
-      $('#allfeaturesdialog').dialog("open")
+    update_all_features_dialog()
 
   $('#featureLibrary').unbind('click').click ->
     console.log("Making request to the backend for the list of features associated with this user")
@@ -144,6 +144,3 @@ window.bind_features = ->
       G.main_editor.startEditing()
 
   $('#upload').unbind('change').bind('change', window.handleFileSelect)
-
-
-


### PR DESCRIPTION
Currently, multiple pop up boxes will show up (e.g. Add Feature & All Features), causing one to block the other.

Ideally, you have 2 choices:
1. Only allow one pop up box at a time;
2. Reposition pop up boxes automatically when there are multiple ones.

In case 2, you should have the All Features pop up update automatically, since currently the new features added will only show up when the next time "List of features" is clicked.

![2013-05-01 00 57 13](https://f.cloud.github.com/assets/1693418/448162/1d204516-b235-11e2-85fc-ba06857ac456.png)
# cs169test
