### PR TITLE
Add a feature should clear the input every time

### DIFF
--- a/app/assets/javascripts/features.js.coffee
+++ b/app/assets/javascripts/features.js.coffee
@@ -56,7 +56,8 @@ update_all_features_dialog = ->
     $('#allfeaturesdialog').dialog("open")
 
 reset_features_form = ->
-  $('feature-form').each -> $(this).reset()
+  $('#feature-form #sequence').val('')
+  $('#feature-form #name').val('')
 
 window.setup_features = ->
   $('#featuredialog').dialog


### PR DESCRIPTION
When I click "Add a feature" after adding a feature, the dialog pop up box still have the feature I added last time.

Ideally, the input fields should be cleared right after a feature is successfully added.

![2013-05-01 00 53 37](https://f.cloud.github.com/assets/1693418/448148/6f0c203a-b234-11e2-846d-422b364bc29e.png)
# cs169test
